### PR TITLE
Use the unminifed script as the "main"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pusher-angular",
   "version": "0.1.4",
   "description": "Angular library for using Pusher",
-  "main": "lib/pusher-angular.min.js",
+  "main": "lib/pusher-angular.js",
   "scripts": {
     "test": "karma start traivs_karma.conf.js"
   },


### PR DESCRIPTION
Using a minified file in your package prevents developers from getting useful stack traces while developing. A more thorough explanation I gave to my good friends @ Firebase:

https://github.com/firebase/angularfire/issues/436#issue-45740939 (see point 2)