### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The first step is to make sure that you have all of the required libraries avail
 <script src="//js.pusher.com/3.0/pusher.min.js"></script>
 
 <!-- pusher-angular -->
-<script src="//cdn.jsdelivr.net/angular.pusher/latest/pusher-angular.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/pusher-angular@latest/lib/pusher-angular.min.js"></script>
 
 <!-- pusher-angular (backup CDN)
 <script src="//cdnjs.cloudflare.com/ajax/libs/pusher-angular/0.1.7/pusher-angular.min.js"></script>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version. You can always find the correct link at https://www.jsdelivr.com/package/npm/pusher-angular.

Feel free to ping me if you have any questions regarding this change.